### PR TITLE
Remove "Hacks" from front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,11 +51,6 @@ target="_blank">@pelegri</a>
 <td><a href="http://glassfish.org" title="Going, Going... not yet gone!">GlassFish</a>
 </td>
 </tr>
-<tr><td align="right"><a href="http://pelegri.github.com/lahacks">LAHacks</a></td>
-<td align="center">&middot;</td>
-<td><a href="http://pelegri.github.com/yhack">YHack</a>
-</td>
-</tr>
 </table>
 </center>
 </body>


### PR DESCRIPTION
Those hackathons are more than 4 years old.

Close #1 